### PR TITLE
SplashScreen ChooseLoginOrSignupScreen and SplashViewModel added

### DIFF
--- a/app/src/main/java/com/example/opinia/ui/AppNavigation.kt
+++ b/app/src/main/java/com/example/opinia/ui/AppNavigation.kt
@@ -2,8 +2,13 @@ package com.example.opinia.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.opinia.ui.onboarding_authentication.ChooseLoginOrSignupScreen
+import com.example.opinia.ui.onboarding_authentication.SplashScreen
+import com.example.opinia.ui.onboarding_authentication.SplashViewModel
 
 
 //BU YOLLAR UPDATE EDİLEBİLİR
@@ -28,7 +33,14 @@ fun AppNavigation(modifier: Modifier = Modifier) {
     val navController = rememberNavController()
 
     NavHost(navController = navController, startDestination = Destination.START.route, builder = {
+            composable(Destination.START.route) {
+                val splashViewModel: SplashViewModel = hiltViewModel()
+                SplashScreen(navController, splashViewModel)
+            }
 
+            composable(Destination.CHOOSE_LOGIN_OR_SIGNUP.route) {
+                ChooseLoginOrSignupScreen(navController)
+            }
         }
     )
 }

--- a/app/src/main/java/com/example/opinia/ui/onboarding_authentication/ChooseLoginOrSignupScreen.kt
+++ b/app/src/main/java/com/example/opinia/ui/onboarding_authentication/ChooseLoginOrSignupScreen.kt
@@ -1,0 +1,104 @@
+package com.example.opinia.ui.onboarding_authentication
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.example.opinia.R
+import com.example.opinia.ui.Destination
+import com.example.opinia.ui.theme.OpiniaDeepBlue
+import com.example.opinia.ui.theme.OpinialightBlue
+
+@Composable
+fun ChooseLoginOrSignupScreen(navController: NavController) {
+    ChooseLoginOrSignupContent(
+        onLoginClick = { navController.navigate(Destination.LOGIN.route) },
+        onSignupClick = { navController.navigate(Destination.SIGNUP_PERSONAL_INFO.route) }
+    )
+}
+
+@Composable
+fun ChooseLoginOrSignupContent(
+    onLoginClick: () -> Unit,
+    onSignupClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(OpiniaDeepBlue)
+    ) {
+
+        Image(
+            painter = painterResource(id = R.drawable.yeni_acikmavi_logo),
+            contentDescription = "Opinia Logo",
+            modifier = Modifier
+                .width(285.dp)
+                .height(85.dp)
+                .align(Alignment.Center)
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 120.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Button(
+                onClick = onLoginClick,
+                modifier = Modifier
+                    .height(40.dp)
+                    .width(200.dp),
+                shape = MaterialTheme.shapes.medium,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = OpinialightBlue,
+                    contentColor = OpiniaDeepBlue
+                )
+            ) {
+                Text("Log In", style = MaterialTheme.typography.bodyMedium.copy(fontSize = 16.sp, fontWeight = FontWeight.Bold))
+            }
+
+            Spacer(modifier = Modifier.height(30.dp))
+
+            Button(
+                onClick = onSignupClick,
+                modifier = Modifier
+                    .height(40.dp)
+                    .width(200.dp),
+                shape = MaterialTheme.shapes.medium,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = OpinialightBlue,
+                    contentColor = OpiniaDeepBlue
+                )
+            ) {
+                Text("Sign Up", style = MaterialTheme.typography.bodyMedium.copy(fontSize = 16.sp, fontWeight = FontWeight.Bold))
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun ChooseLoginOrSignupPreview() {
+    ChooseLoginOrSignupContent(onLoginClick = {}, onSignupClick = {})
+}

--- a/app/src/main/java/com/example/opinia/ui/onboarding_authentication/SplashScreen.kt
+++ b/app/src/main/java/com/example/opinia/ui/onboarding_authentication/SplashScreen.kt
@@ -1,0 +1,84 @@
+package com.example.opinia.ui.onboarding_authentication
+
+import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.opinia.R
+import com.example.opinia.ui.Destination
+import com.example.opinia.ui.theme.OpiniaDeepBlue
+
+@Composable
+fun SplashScreen(navController: NavController, splashViewModel: SplashViewModel) {
+
+    val uiState by splashViewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(uiState) {
+        when (val state = uiState) {
+            is SplashUiState.GoToDashboard -> {
+                navController.navigate(Destination.DASHBOARD.route) {
+                    popUpTo(Destination.START.route) { inclusive = true }
+                }
+            }
+            is SplashUiState.GoToChooseLoginOrSignup -> {
+                navController.navigate(Destination.CHOOSE_LOGIN_OR_SIGNUP.route) {
+                    popUpTo(Destination.START.route) { inclusive = true }
+                }
+            }
+            is SplashUiState.NoInternet -> {
+                Toast.makeText(context, "No internet connection", Toast.LENGTH_SHORT).show()
+            }
+            is SplashUiState.Loading -> {
+                Unit //sadece beklesin
+            }
+        }
+    }
+
+    SplashScreenContent()
+}
+
+@Composable
+fun SplashScreenContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(OpiniaDeepBlue),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.yeni_acikmavi_logo),
+                contentDescription = "Logo",
+                modifier = Modifier
+                    .width(285.dp)
+                    .height(85.dp)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SplashScreenPreview() {
+    SplashScreenContent()
+}

--- a/app/src/main/java/com/example/opinia/ui/onboarding_authentication/SplashViewModel.kt
+++ b/app/src/main/java/com/example/opinia/ui/onboarding_authentication/SplashViewModel.kt
@@ -1,0 +1,52 @@
+package com.example.opinia.ui.onboarding_authentication
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.opinia.data.repository.AuthRepository
+import com.example.opinia.data.repository.AuthState
+import com.example.opinia.utils.NetworkManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed class SplashUiState {
+    data object Loading : SplashUiState()
+    data object NoInternet : SplashUiState()
+    data object GoToChooseLoginOrSignup : SplashUiState()
+    data object GoToDashboard : SplashUiState()
+}
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(private val networkManager: NetworkManager, private val authRepository: AuthRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<SplashUiState>(SplashUiState.Loading)
+    val uiState: StateFlow<SplashUiState> = _uiState.asStateFlow()
+
+    init{
+        checkAppStartConditions()
+    }
+
+    fun checkAppStartConditions() {
+        viewModelScope.launch {
+            _uiState.value = SplashUiState.Loading
+            if (!networkManager.isInternetAvailable()) {
+                _uiState.value = SplashUiState.NoInternet
+                delay(5000) //5 saniye bekle
+                checkAppStartConditions()
+                return@launch
+            }
+            authRepository.authState.collect { authState ->
+                _uiState.value = when (authState) {
+                    is AuthState.Authenticated -> SplashUiState.GoToDashboard
+                    is AuthState.Unauthenticated -> SplashUiState.GoToChooseLoginOrSignup
+                    is AuthState.Loading -> SplashUiState.Loading
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### Add Splash Screen, Login Choice and Navigation

- AppNavigation: defined navigation routes.
- Splash Logic: Implemented SplashViewModel to handle network checks and redirect users based on their auth status.
- UI: Added the SplashScreen and the ChooseLoginOrSignupScreen using the new design system from the figma.
- Routing: Configured navigation actions to handle the transition from Splash to the appropriate destination.