### PR TITLE
fix: enable navigation to course detail from search bar

### DIFF
--- a/app/src/main/java/com/example/opinia/ui/Instructor/InstructorCatalogScreen.kt
+++ b/app/src/main/java/com/example/opinia/ui/Instructor/InstructorCatalogScreen.kt
@@ -87,7 +87,9 @@ fun InstructorCatalogContent(
                 ) {
                     GeneralSearchBar(
                         searchViewModel = searchViewModel,
-                        onNavigateToCourse = { },
+                        onNavigateToCourse = { courseId ->
+                            navController.navigate(Destination.COURSE_DETAIL.route.replace("{courseId}", courseId))
+                        },
                         onNavigateToInstructor = { instructor ->
                             val deptId = instructor.departmentIds.firstOrNull() ?: "unknown"
                             val route = Destination.INSTRUCTOR_LIST.route

--- a/app/src/main/java/com/example/opinia/ui/Instructor/InstructorListScreen.kt
+++ b/app/src/main/java/com/example/opinia/ui/Instructor/InstructorListScreen.kt
@@ -93,7 +93,9 @@ fun InstructorListContent(
                 ) {
                     GeneralSearchBar(
                         searchViewModel = searchViewModel,
-                        onNavigateToCourse = { }, // Burası boş kalabilir
+                        onNavigateToCourse = { courseId ->
+                            navController.navigate(Destination.COURSE_DETAIL.route.replace("{courseId}", courseId))
+                        }, // Burası boş kalabilir
                         onNavigateToInstructor = { instructor ->
                             // Arama sonucuna tıklayınca o hocaya gitme mantığı
                             val deptId = instructor.departmentIds.firstOrNull() ?: "unknown"


### PR DESCRIPTION
- implemented onNavigateToCourse callback in InstructorCatalogScreen
- implemented onNavigateToCourse callback in InstructorListScreen
- fixed issue where clicking a course in search results did not navigate to details